### PR TITLE
Update bindgen to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 links = "laszip"
 
 [build-dependencies]
-bindgen = "0.30"
+bindgen = "0.53.1"
 
 [dev-dependencies]
-tempfile = "2.2"
+tempfile = "3.1.0"


### PR DESCRIPTION
Fixes compile error in syntex_syntax with 1.41.0, see https://github.com/rust-lang/rust/issues/68729

I ran the tests on 1.38 and 1.41, both pass.

Would be nice to have an update on crates.io :) (I did not up the version nr)